### PR TITLE
fix: use correct argument names for binary

### DIFF
--- a/.github/workflows/helm-repo-index-DEV.yaml
+++ b/.github/workflows/helm-repo-index-DEV.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run
-        run: .github/bin/helmRepoIndex -gitOwner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }} -indexFile "dev/index.yaml"
+        run: .github/bin/helmRepoIndex -owner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }} -indexFile "dev/index.yaml"
 
       - name: Publish changes
         run: |


### PR DESCRIPTION
GiHub workflow used wrong argument for `helmRepoIndex` binary.