### PR TITLE
chore: refactor helmRepoIndex Go binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - This `CHANGELOG.md` file
 - GitHub Workflow - PullRequest linting
-- GitHub Workflow - Release Drafter
 
 ### Changed
 
+#### helmRepoIndex Go Code
+
 - remove obsolete check for existing `gh-pages` branch in `func main`
 - remove check `StatusCode == 200` from previous branch check
-- Refactor func `downloadProductHelmRepoIndex` and error handling
+- func `downloadProductHelmRepoIndex`: Download `index.yaml` via GH RAW URL, error handling, add log output
+- func `buildHelmRepoIndex` add log output
 
 ## [0.0.4] - 2022-11-28
 

--- a/src/helmRepoIndex/main.go
+++ b/src/helmRepoIndex/main.go
@@ -134,7 +134,7 @@ func downloadProductHelmRepoIndex(gitOwner string, gitRepo string) (string, erro
 	}
 }
 
-func buildHelmRepoIndex(indexFile string, mergeIndexFile string) {
+func buildHelmRepoIndex(indexFile string, mergeIndexFile string, gitRepo string) {
 	repoFile, err := repo.LoadIndexFile(indexFile)
 	if err != nil {
 		log.Fatal(err)
@@ -148,6 +148,7 @@ func buildHelmRepoIndex(indexFile string, mergeIndexFile string) {
 			log.Fatal(err)
 		}
 		repoFile.Merge(newIndex)
+		log.Printf("✅  %v - index.yaml merged into Helm repository", gitRepo)
 		repoFile.Generated = time.Now()
 		err = repoFile.WriteFile(indexFile, 0644)
 

--- a/src/helmRepoIndex/main.go
+++ b/src/helmRepoIndex/main.go
@@ -55,17 +55,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	for i, gitRepo := range repos {
+	for _, gitRepo := range repos {
 		var gitRepoHelmIndex string
 
-		//check gh pages configured for repo
-		_, response, _ := client.Repositories.GetBranch(ctx, gitOwner, *gitRepo.Name, "gh-pages", false)
-
-		if response.StatusCode == 200 {
-			fmt.Println(i, *gitRepo.Name)
-			gitRepoHelmIndex = downloadProductHelmRepoIndex(gitOwner, *gitRepo.Name)
-			buildHelmRepoIndex(indexFile, gitRepoHelmIndex)
+		gitRepoHelmIndex, err = downloadProductHelmRepoIndex(gitOwner, *gitRepo.Name)
+		if err != nil {
+			fmt.Println(err)
+			continue
 		}
+		buildHelmRepoIndex(indexFile, gitRepoHelmIndex, *gitRepo.Name)
 	}
 }
 

--- a/src/helmRepoIndex/main.go
+++ b/src/helmRepoIndex/main.go
@@ -128,7 +128,7 @@ func downloadProductHelmRepoIndex(gitOwner string, gitRepo string) (string, erro
 		return fileName, nil
 	} else {
 		dt := time.Now()
-		return "", fmt.Errorf("%v ❌  %v - no index.yaml found", dt.Format("01/02/2006 15:04:05"), gitRepo)
+		return "", fmt.Errorf("%v ❌  %v - no index.yaml found", dt.Format("2006/01/02 15:04:05"), gitRepo)
 	}
 }
 

--- a/src/helmRepoIndex/main.go
+++ b/src/helmRepoIndex/main.go
@@ -146,7 +146,7 @@ func buildHelmRepoIndex(indexFile string, mergeIndexFile string, gitRepo string)
 			log.Fatal(err)
 		}
 		repoFile.Merge(newIndex)
-		log.Printf("✅  %v - index.yaml merged into Helm repository", gitRepo)
+		log.Printf("✅  %v - index.yaml merged into Helm repository DEV", gitRepo)
 		repoFile.Generated = time.Now()
 		err = repoFile.WriteFile(indexFile, 0644)
 


### PR DESCRIPTION
Some structural changes to the Go code:

- no more check for existing `gp-pages` branch and and looping over repos having a `gh-pages` branch in func main
- func `downloadProductHelmRepoIndex`:
  - if download of `index.yaml` succeeded, create temp repo index file
  - restructure close of file, response.Body handle → use of defer
  - added log output
- func `buildHelmRepoIndex`: added log output
- maintain `CHANGELOG.md`

For each repository out is generated, before output was generated only if index.yaml was found. Output look now like this:

```shell
2022/12/11 15:01:31 ✅  repoName1 - index.yaml download completed
2022/12/11 15:01:31 ✅  repoName1 - index.yaml merged into Helm repository DEV
2022/12/11 15:01:31 ✅  repoName2 - index.yaml download completed
2022/12/11 15:01:31 ✅  repoName3 - index.yaml merged into Helm repository DEV
2022/12/11 15:01:31 ❌  repoName4 - no index.yaml found
2022/12/11 15:01:31 ❌  repoName5 - no index.yaml found
2022/12/11 15:01:31 ❌  repoName6 - no index.yaml found
2022/12/11 15:01:31 ❌  repoName7 - no index.yaml found
...
```