### PR TITLE
chore(add): add GitHub workflows incl. wf config

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,122 @@
+# Copyright (c) 2021,2022 Mercedes-Benz Tech Innovation GmbH
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Config file for GH Action release-drafter
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "📄 Documentation"
+    labels:
+      - "documentation"
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+  - title: "🧰 Maintenance"
+    label: "chore"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+autolabeler:
+  - label: "bug"
+    branch:
+      - '/^(bug|fix|bugfix)\/.+/'
+    title:
+      - "/^(bug|fix|bugfix):.+/"
+      - '/^(bug|fix|bugfix)(\(.+\)):.+/'
+  - label: "chore"
+    branch:
+      - '/^(chore)\/.+/'
+    title:
+      - "/^(chore):.+/"
+      - '/^(chore)(\(.+\)):.+/'
+  - label: "documentation"
+    branch:
+      - '/^(docs?|documentation)\/.+/'
+    files:
+      - "*.md"
+    title:
+      - "/^(docs?|documentation):.+/"
+      - '/^(docs?|documentation)(\(.+\)):.+/'
+  - label: "enhancement"
+    branch:
+      - '/^(feat|feature|enhancement)\/.+/'
+    title:
+      - "/^(feat|feature|enhancement):.+/"
+      - '/^(feat|feature|enhancement)(\(.+\)):.+/'
+
+  # label skip-changelog when either title or body or PR indicates GH Action/Workflow
+  # https://regex101.com/r/v15bku/1
+  - label: "skip-changelog"
+    title:
+      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
+    body:
+      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
+
+  # version-resolver labels
+  # if a PR only fixes some bugs the patch should be updated
+  - label: "patch"
+    branch:
+      - '/^(fix)\/.+/'
+      - '/^(chore)\/.+/'
+    title:
+      - "/^(bug|fix|bugfix):.+/"
+      - '/^(bug|fix|bugfix)(\(.+\)):.+/'
+      - "/^(chore):.+/"
+      - '/^(chore)(\(.+\)):.+/'
+  # if a PR adds a feature the minor should be updated (when no breaking changes)
+  - label: "minor"
+    branch:
+      - '/^(feat|feature|enhancement)\/.+/'
+    title:
+      - "/^(feat|feature|enhancement):.+/"
+      - '/^(feat|feature|enhancement)(\(.+\)):.+/'
+  # if a PR adds a breaking-change feature the major should be updated
+  - label: "major"
+    branch:
+      - '/^(feat|feature|chore|fix|enhancement)!\/.+/'
+    title:
+      - "/^(feat|feature|chore|fix|enhancement)!:.+/"
+      - '/^(feat|feature|chore|fix|enhancement)(\(.+\))!:.+/'
+    body:
+      - '/BREAKING\ CHANGE/'
+
+exclude-labels:
+  - "skip-changelog"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+# Copyright (c) 2021,2022 Mercedes-Benz Tech Innovation GmbH
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Config file for automatically generated GH release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+    authors:
+      - github-actions
+  categories:
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "bug"
+    - title: "📄 Documentation"
+      labels:
+        - "documentation"
+    - title: "🚀 Features"
+      labels:
+        - "enhancement"
+    - title: "🧰 Maintenance"
+      label: "chore"

--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2021,2022 Mercedes-Benz Tech Innovation GmbH
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: .github/bin/helmRepoIndex
+          generate_release_notes: true

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2021,2022 Mercedes-Benz Tech Innovation GmbH
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # for release-drafter/release-drafter to create a github release
+      pull-requests: write # for release-drafter/release-drafter to add label to PR
+
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add 2 GitHub workflows to implement a GH release workflow:
- Release Drafter
- Create GitHub Release

Release Drafter:
- Monitors main branch and incoming pull requests
- Pull requests are labeled automatically when opened
- when PR merged to main (push), a draft release will be created or updated

Create GitHub Release:
- workflow trigger on push of SemVer tags
- generates a GH release based on release draft