### PR TITLE
chore: remove non-existent helm chart version

### DIFF
--- a/dev/index.yaml
+++ b/dev/index.yaml
@@ -310,16 +310,6 @@ entries:
     urls:
     - https://github.com/eclipse-tractusx/sd-factory/releases/download/sdfactory-1.1.0/sdfactory-1.1.0.tgz
     version: 1.1.0
-  - apiVersion: v2
-    appVersion: 1.0.6
-    created: "2022-12-09T12:46:07.296263622Z"
-    description: A Helm chart for SDFactory
-    digest: 69659e1a9616f0389f336baa2a28b6e1dad78976fbecade29953940f5e8773a7
-    name: sdfactory
-    type: application
-    urls:
-    - https://github.com/eclipse-tractusx/sd-factory/releases/download/sdfactory-1.0.6/sdfactory-1.0.6.tgz
-    version: 1.0.6
   semantic-hub:
   - apiVersion: v2
     appVersion: 0.1.0-M2
@@ -331,4 +321,4 @@ entries:
     urls:
     - https://github.com/eclipse-tractusx/sldt-semantic-hub/releases/download/semantic-hub-0.1.3/semantic-hub-0.1.3.tgz
     version: 0.1.3
-generated: "2022-12-13T14:35:47.913062937Z"
+generated: "2022-12-13T14:38:22.918762937Z"


### PR DESCRIPTION
Removed non-existent Helm Chart for `sd-factory` version 1.0.6.