### PR TITLE
chore: update Helm repo MD files, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Helm Repository is split into two repositories:
 Both repositories will be hosted via GitHub Pages within this
 repository ([eclipse-tractus-x/charts](https://github.com/eclipse-tractusx/charts)) and will be accessible under URL
 
-- https://eclipse-tractusx.github.io/charts/dev for Dev
-- https://eclipse-tractusx.github.io/charts/stable for Stable
+- [https://eclipse-tractusx.github.io/charts/dev](https://eclipse-tractusx.github.io/charts/dev) for Dev
+- [https://eclipse-tractusx.github.io/charts/stable](https://eclipse-tractusx.github.io/charts/stable) for Stable
 
 ## Availability
 
@@ -37,10 +37,21 @@ The Stable Helm repository will be updated when a new Tractus-X release or a pat
 
 ```shell
 $ helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-$ helm search repo tractusx-dev/portal
-NAME                    CHART VERSION   APP VERSION     DESCRIPTION                            
-tractusx-dev/portal         0.8.0           0.8.0           Helm chart for Catena-X Portal frontend
-tractusx-dev/portal-backend 0.8.0           0.8.0           Helm chart for Catena-X Portal backend
+$ $ helm search repo tractusx-dev
+NAME                         	CHART VERSION	APP VERSION           	DESCRIPTION
+tractusx-dev/autosetup       	1.0.1        	0.0.2                 	A Helm chart for Kubernetes
+tractusx-dev/bpdm            	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM service
+tractusx-dev/bpdm-gate       	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM gate service
+tractusx-dev/daps-server     	1.7.2        	1.7.1                 	DAPS server helm-chart
+tractusx-dev/dft-backend     	1.7.0        	1.7.0                 	A Helm chart for DFT application
+tractusx-dev/dft-frontend    	1.7.0        	1.7.0                 	A Helm chart for Kubernetes
+tractusx-dev/irs             	1.1.1        	1.1.0                 	IRS Helm chart for Kubernetes for Catena-X
+tractusx-dev/irs-edc-consumer	1.0.1        	0.1.2                 	IRS Helm chart for the EDC consumer
+tractusx-dev/irs-helm        	4.0.0        	2.0.0                 	IRS Helm chart for Kubernetes
+tractusx-dev/portal          	0.6.0        	0.6.0                 	Helm chart for Catena-X Portal
+tractusx-dev/registry        	0.2.4        	0.2.0-M4-multi-tenancy	Tractus-X Digital Twin Registry Helm Chart
+tractusx-dev/sdfactory       	1.1.0        	1.1.0                 	A Helm chart for SDFactory
+tractusx-dev/semantic-hub    	0.1.3        	0.1.0-M2              	Helm Chart for the Catena-X Semantic Hub Applic...
 $ helm install tractusx-dev/portal
 [...]
 ```
@@ -49,10 +60,13 @@ $ helm install tractusx-dev/portal
 
 ```shell
 $ helm repo add tractusx https://eclipse-tractusx.github.io/charts/dev
-$ helm search repo tractusx/portal
-NAME                    CHART VERSION   APP VERSION     DESCRIPTION                            
-tractusx/portal         0.8.0           0.8.0           Helm chart for Catena-X Portal frontend
-tractusx/portal-backend 0.8.0           0.8.0           Helm chart for Catena-X Portal backend
+$ $ helm search repo tractusx
+NAME                         	CHART VERSION	APP VERSION           	DESCRIPTION
+tractusx/bpdm            	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM service
+tractusx/bpdm-gate       	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM gate service
+tractusx/daps-server     	1.7.2        	1.7.1                 	DAPS server helm-chart
+tractusx/irs-helm        	4.0.0        	2.0.0                 	IRS Helm chart for Kubernetes
+tractusx/portal          	0.6.0        	0.6.0                 	Helm chart for Catena-X Portal
 $ helm install tractusx/portal
 [...]
 ```

--- a/dev/README.md
+++ b/dev/README.md
@@ -7,10 +7,21 @@ to [documentation](../README.md#availability).
 
 ```shell
 $ helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-$ helm search repo tractusx-dev/portal
-NAME                    CHART VERSION   APP VERSION     DESCRIPTION                            
-tractusx-dev/portal         0.8.0           0.8.0           Helm chart for Catena-X Portal frontend
-tractusx-dev/portal-backend 0.8.0           0.8.0           Helm chart for Catena-X Portal backend
+$ $ helm search repo tractusx-dev
+NAME                         	CHART VERSION	APP VERSION           	DESCRIPTION
+tractusx-dev/autosetup       	1.0.1        	0.0.2                 	A Helm chart for Kubernetes
+tractusx-dev/bpdm            	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM service
+tractusx-dev/bpdm-gate       	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM gate service
+tractusx-dev/daps-server     	1.7.2        	1.7.1                 	DAPS server helm-chart
+tractusx-dev/dft-backend     	1.7.0        	1.7.0                 	A Helm chart for DFT application
+tractusx-dev/dft-frontend    	1.7.0        	1.7.0                 	A Helm chart for Kubernetes
+tractusx-dev/irs             	1.1.1        	1.1.0                 	IRS Helm chart for Kubernetes for Catena-X
+tractusx-dev/irs-edc-consumer	1.0.1        	0.1.2                 	IRS Helm chart for the EDC consumer
+tractusx-dev/irs-helm        	4.0.0        	2.0.0                 	IRS Helm chart for Kubernetes
+tractusx-dev/portal          	0.6.0        	0.6.0                 	Helm chart for Catena-X Portal
+tractusx-dev/registry        	0.2.4        	0.2.0-M4-multi-tenancy	Tractus-X Digital Twin Registry Helm Chart
+tractusx-dev/sdfactory       	1.1.0        	1.1.0                 	A Helm chart for SDFactory
+tractusx-dev/semantic-hub    	0.1.3        	0.1.0-M2              	Helm Chart for the Catena-X Semantic Hub Applic...
 $
 ```
 

--- a/stable/README.md
+++ b/stable/README.md
@@ -3,14 +3,20 @@
 Helm charts to deploy Tractus-X products. For differences between the DEV and Stable Helm repository, please refer
 to [documentation](../README.md#availability).
 
+Attention:  
+The Stable Helm Repository hasn't been initialized yet. Command output below is for demonstration only.
+
 # Add Tractus-X Helm Repository
 
 ```shell
 $ helm repo add tractusx https://eclipse-tractusx.github.io/charts/stable
-$ helm search repo tractusx/portal
-NAME                    CHART VERSION   APP VERSION     DESCRIPTION                            
-tractusx/portal         0.8.0           0.8.0           Helm chart for Catena-X Portal frontend
-tractusx/portal-backend 0.8.0           0.8.0           Helm chart for Catena-X Portal backend
+$ $ helm search repo tractusx
+NAME                         	CHART VERSION	APP VERSION           	DESCRIPTION
+tractusx/bpdm            	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM service
+tractusx/bpdm-gate       	2.0.0        	2.0.0                 	A Helm chart for deploying the BPDM gate service
+tractusx/daps-server     	1.7.2        	1.7.1                 	DAPS server helm-chart
+tractusx/irs-helm        	4.0.0        	2.0.0                 	IRS Helm chart for Kubernetes
+tractusx/portal          	0.6.0        	0.6.0                 	Helm chart for Catena-X Portal
 $
 ```
 


### PR DESCRIPTION
Updated `helm search repo` output for _DEV_ and _Stable_ Helm Repo info page and GH `README.md`. Fixed Markdown links in `README.md`.