### PR TITLE
fix: typo in gh-release.yaml

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -60,6 +60,6 @@ jobs:
         with:
           files: |
             .github/bin/helmRepoIndex
-            CHANGELOG.mg
+            CHANGELOG.md
             LICENSE
           generate_release_notes: true


### PR DESCRIPTION
In the Release step the CHANGELOG.md file had a typo