### PR TITLE
chore: add .tractusx metafile

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "Eclipse-Tractusx Charts"
+leadingRepository: "https://github.com/eclipse-tractusx/charts"
+repositories:
+- name: "charts"
+  usage: "all Tractus-X sub-product as Helm Charts"
+  url: "https://github.com/eclipse-tractusx/charts"


### PR DESCRIPTION
## add Metadata file for this repo

This PR adds an initial version of the `.tractusx` metadata file like described in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5).
If there are any other repositories, that are connected to the this repository, that together form a product, please point that out or add the connected repos later on

Fixes #31 