### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -27,11 +27,11 @@ jobs:
   go-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'src/helmRepoIndex/go.mod'
 
@@ -56,12 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            .github/bin/helmRepoIndex
-            CHANGELOG.md
-            LICENSE
-          generate_release_notes: true
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:              files: |
+                .github/bin/helmRepoIndex
+                CHANGELOG.md
+                LICENSE
+              generate_release_notes: true

--- a/.github/workflows/pullRequest-lint.yaml
+++ b/.github/workflows/pullRequest-lint.yaml
@@ -12,12 +12,12 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -36,7 +36,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3
         with:
           header: pr-title-lint-error
           delete: true


### PR DESCRIPTION
### Context
This pull request is part of the security hardening initiative for the `eclipse-tractusx` organization.The goal is to replace mutable GitHub Action version tags with immutable commit SHAs.

### Changes
- Pinned `actions/setup-go`, `softprops/action-gh-release`, `amannn/action-semantic-pull-request`, and `marocchino/sticky-pull-request-comment` to immutable commit SHAs across 2 workflow files.

### Verification
- Resolved the version tags to their corresponding commit SHAs using the GitHub API.
